### PR TITLE
Display Dynamo Advance Steel Version alongside with Dynamo Core Version 

### DIFF
--- a/src/DynamoAdvanceSteel/AdvanceSteelPathResolver.cs
+++ b/src/DynamoAdvanceSteel/AdvanceSteelPathResolver.cs
@@ -10,10 +10,10 @@ namespace Dynamo.Applications
     private readonly List<string> preloadLibraryPaths;
     private readonly List<string> additionalNodeDirectories;
     private readonly List<string> additionalResolutionPaths;
-		private readonly string userDataRootFolder;
-		private readonly string commonDataRootFolder;
+    private readonly string userDataRootFolder;
+    private readonly string commonDataRootFolder;
 
-		internal AdvanceSteelPathResolver(string userDataFolder, string commonDataFolder)
+    internal AdvanceSteelPathResolver(string userDataFolder, string commonDataFolder)
     {
       string addinDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
@@ -52,9 +52,9 @@ namespace Dynamo.Applications
 
       // Add the Revit_20xx folder for assembly resolution
       additionalResolutionPaths = new List<string> { currentAssemblyDir };
-			userDataRootFolder = userDataFolder;
-			commonDataRootFolder = commonDataFolder;
-		}
+      userDataRootFolder = userDataFolder;
+      commonDataRootFolder = commonDataFolder;
+    }
 
     public IEnumerable<string> AdditionalNodeDirectories
     {
@@ -73,14 +73,12 @@ namespace Dynamo.Applications
 
     public string UserDataRootFolder
     {
-      get { return string.Empty; }
+      get { return userDataRootFolder; }
     }
 
     public string CommonDataRootFolder
     {
-      get {
-				return Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "Dynamo", "Dynamo Advance Steel");
-			}
+      get { return commonDataRootFolder; }
     }
-	}
+  }
 }

--- a/src/DynamoAdvanceSteel/CommandClass.cs
+++ b/src/DynamoAdvanceSteel/CommandClass.cs
@@ -4,6 +4,7 @@ using Dynamo.Controls;
 using Dynamo.ViewModels;
 using DynamoShapeManager;
 using System;
+using System.Reflection;
 using MessageBox = System.Windows.Forms.MessageBox;
 
 [assembly: CommandClassAttribute(typeof(Dynamo.Applications.CommandClass))]
@@ -30,6 +31,11 @@ namespace Dynamo.Applications
         InitializeCore();
 
         advanceSteelModel = InitializeCoreModel();
+        // get Dynamo Advance Steel Version
+        var asDynamoVersion = Assembly.GetExecutingAssembly().GetName().Version;
+        advanceSteelModel.HostName = "Dynamo AS";
+        advanceSteelModel.HostVersion = asDynamoVersion.ToString();
+
         dynamoViewModel = InitializeCoreViewModel(advanceSteelModel);
 
         //show dynamo window


### PR DESCRIPTION
In DynamoAdvance Steel, whenever users clicked on the 'Help' -> 'About' menu, they will see the window as follows:

![screen shot 2016-12-13 at 16 11 53](https://cloud.githubusercontent.com/assets/13578579/21153131/503b88ce-c150-11e6-9bcd-8d4b639da953.png)
